### PR TITLE
align decimal max and min validators with jakarta implementation

### DIFF
--- a/valdr-ng/projects/valdr-ng/src/lib/validators/base-decimal-factory.ts
+++ b/valdr-ng/projects/valdr-ng/src/lib/validators/base-decimal-factory.ts
@@ -12,21 +12,12 @@ import { AbstractControl, ValidatorFn } from '@angular/forms';
 export abstract class DecimalFactory extends BaseValidatorFactory {
   createValidator(config: DecimalValidatorConfig): ValdrValidatorFn {
     return (control: AbstractControl): ValdrValidationErrors | null => {
-      if (config.inclusive) {
-        return this.handleInclusive(config, control);
+      if (!this.getMainValidator(config.value)(control)) {
+        return null;
       }
-      return this.handleExclusive(config, control);
+      return this.getValidationErrors(config);
     };
   }
-
-  /**
-   * Checks if the numbers are exclusive.
-   *
-   * @param a the control value
-   * @param b the config value
-   * @return true if exclusive
-   */
-  abstract isExclusive(a: number, b: number): boolean;
 
   /**
    * Gets the main validator for the given value.
@@ -34,29 +25,6 @@ export abstract class DecimalFactory extends BaseValidatorFactory {
    * @param value the number limit
    */
   abstract getMainValidator(value: number): ValidatorFn;
-
-  private handleExclusive(
-    config: DecimalValidatorConfig,
-    control: AbstractControl
-  ): ValdrValidationErrors | null {
-    if (!control.value || isNaN(control.value)) {
-      return null;
-    }
-    if (this.isExclusive(Number(control.value), config.value)) {
-      return null;
-    }
-    return this.getValidationErrors(config);
-  }
-
-  private handleInclusive(
-    config: DecimalValidatorConfig,
-    control: AbstractControl
-  ) {
-    if (!this.getMainValidator(config.value)(control)) {
-      return null;
-    }
-    return this.getValidationErrors(config);
-  }
 
   private getValidationErrors({ value, message }: any) {
     return {

--- a/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-max-factory.spec.ts
+++ b/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-max-factory.spec.ts
@@ -25,7 +25,7 @@ describe('DecimalMaxFactory', () => {
       ).toBeDefined();
     });
 
-    describe('should validate inclusive properly', () => {
+    describe('should validate allowed values', () => {
       let validator: ValdrValidatorFn | null = {} as any;
 
       beforeEach(() => {
@@ -56,58 +56,31 @@ describe('DecimalMaxFactory', () => {
         const result = validator!(control);
 
         // then
-        expect(result).toEqual(
-          jasmine.objectContaining({
-            max: {
-              value: 10,
-              message: 'Should be less than 10.',
-            },
-          })
-        );
-      });
-    });
-
-    describe('should validate exclusive properly', () => {
-      let validator: ValdrValidatorFn | null = {} as any;
-
-      beforeEach(() => {
-        validator = decimalMaxFactory!.createValidator({
-          value: 20,
-          message: 'Should be less than 20.',
-          inclusive: false,
-        });
-      });
-
-      afterAll(() => (validator = null));
-
-      it('should not add message on lesser value', () => {
-        // given
-        const control: FormControl = new FormControl(19);
-
-        // when
-        const result = validator!(control);
-
-        // then
         expect(result).toBeNull();
       });
-
-      it('should add message on equal value', () => {
-        // given
-        const control: FormControl = new FormControl('20');
-
-        // when
-        const result = validator!(control);
-
-        // then
-        expect(result).toEqual(
-          jasmine.objectContaining({
-            max: {
-              value: 20,
-              message: 'Should be less than 20.',
-            },
-          })
-        );
-      });
     });
+
+    it('should add message on larger value', () => {
+      // given
+      const validator = decimalMaxFactory!.createValidator({
+        value: 10,
+        message: 'Should be less than 10.',
+      });
+      const control: FormControl = new FormControl('11');
+
+      // when
+      const result = validator!(control);
+
+      // then
+      expect(result).toEqual(
+        jasmine.objectContaining({
+          max: {
+            value: 10,
+            message: 'Should be less than 10.',
+          },
+        })
+      );
+    });
+
   });
 });

--- a/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-max-factory.ts
+++ b/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-max-factory.ts
@@ -15,7 +15,4 @@ export class DecimalMaxFactory extends DecimalFactory {
     return Validators.max(value);
   }
 
-  isExclusive(a: number, b: number): boolean {
-    return a < b;
-  }
 }

--- a/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-min-factory.spec.ts
+++ b/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-min-factory.spec.ts
@@ -25,7 +25,7 @@ describe('DecimalMinFactory', () => {
       ).toBeDefined();
     });
 
-    describe('should validate inclusive properly', () => {
+    describe('should validate allowed values', () => {
       let validator: ValdrValidatorFn | null = {} as any;
 
       beforeEach(() => {
@@ -48,41 +48,9 @@ describe('DecimalMinFactory', () => {
         expect(result).toBeNull();
       });
 
-      it('should add message on equal value', () => {
+      it('should not add message on equal value', () => {
         // given
-        const control: FormControl = new FormControl('10');
-
-        // when
-        const result = validator!(control);
-
-        // then
-        expect(result).toEqual(
-          jasmine.objectContaining({
-            min: {
-              value: 10,
-              message: 'Should be greater than 10.',
-            },
-          })
-        );
-      });
-    });
-
-    describe('should validate exclusive properly', () => {
-      let validator: ValdrValidatorFn | null = {} as any;
-
-      beforeEach(() => {
-        validator = decimalMinFactory!.createValidator({
-          value: 20,
-          message: 'Should be greater than 20.',
-          inclusive: false,
-        });
-      });
-
-      afterAll(() => (validator = null));
-
-      it('should not add message on valid value', () => {
-        // given
-        const control: FormControl = new FormControl(21);
+        const control: FormControl = new FormControl(10);
 
         // when
         const result = validator!(control);
@@ -90,24 +58,29 @@ describe('DecimalMinFactory', () => {
         // then
         expect(result).toBeNull();
       });
-
-      it('should add message on equal value', () => {
-        // given
-        const control: FormControl = new FormControl('20');
-
-        // when
-        const result = validator!(control);
-
-        // then
-        expect(result).toEqual(
-          jasmine.objectContaining({
-            min: {
-              value: 20,
-              message: 'Should be greater than 20.',
-            },
-          })
-        );
-      });
     });
+
+    it('should add message on less value', () => {
+      // given
+      const validator = decimalMinFactory!.createValidator({
+        value: 10,
+        message: 'Should be greater than 10.',
+      });
+      const control: FormControl = new FormControl('9');
+
+      // when
+      const result = validator!(control);
+
+      // then
+      expect(result).toEqual(
+        jasmine.objectContaining({
+          min: {
+            value: 10,
+            message: 'Should be greater than 10.',
+          },
+        })
+      );
+    });
+
   });
 });

--- a/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-min-factory.ts
+++ b/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-min-factory.ts
@@ -15,7 +15,4 @@ export class DecimalMinFactory extends DecimalFactory {
     return Validators.min(value);
   }
 
-  isExclusive(a: number, b: number): boolean {
-    return a > b;
-  }
 }


### PR DESCRIPTION
Jakarta considers equal values valid and it is not possible to set inclusive in the config. Therefor I would propose to get rid of inclusive/exclusive and always consider inclusive as a valid value.