### PR TITLE
align decimal max and min validators with jakarta implementation

### DIFF
--- a/valdr-ng/package.json
+++ b/valdr-ng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valdr-ng",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/valdr-ng/projects/valdr-ng/package.json
+++ b/valdr-ng/projects/valdr-ng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valdr-ng",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Library for creating Angular reactive form configuration.",
   "homepage": "https://github.com/Stanoja/ValdrNG",
   "author": {

--- a/valdr-ng/projects/valdr-ng/src/lib/validators/base-decimal-factory.ts
+++ b/valdr-ng/projects/valdr-ng/src/lib/validators/base-decimal-factory.ts
@@ -12,10 +12,10 @@ import { AbstractControl, ValidatorFn } from '@angular/forms';
 export abstract class DecimalFactory extends BaseValidatorFactory {
   createValidator(config: DecimalValidatorConfig): ValdrValidatorFn {
     return (control: AbstractControl): ValdrValidationErrors | null => {
-      if (config.inclusive) {
-        return this.handleInclusive(config, control);
+      if (config.inclusive === false) {
+        return this.handleExclusive(config, control);
       }
-      return this.handleExclusive(config, control);
+      return this.handleInclusive(config, control);
     };
   }
 

--- a/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-max-factory.spec.ts
+++ b/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-max-factory.spec.ts
@@ -25,13 +25,13 @@ describe('DecimalMaxFactory', () => {
       ).toBeDefined();
     });
 
-    describe('should validate inclusive properly', () => {
+    describe('should validate without inclusive configuration properly', () => {
       let validator: ValdrValidatorFn | null = {} as any;
 
       beforeEach(() => {
         validator = decimalMaxFactory!.createValidator({
           value: 10,
-          message: 'Should be less than 10.',
+          message: 'Should be equal or less than 10.',
         });
       });
 
@@ -56,14 +56,43 @@ describe('DecimalMaxFactory', () => {
         const result = validator!(control);
 
         // then
-        expect(result).toEqual(
-          jasmine.objectContaining({
-            max: {
-              value: 10,
-              message: 'Should be less than 10.',
-            },
-          })
-        );
+        expect(result).toEqual(null);
+      });
+    });
+
+    describe('should validate inclusive properly', () => {
+      let validator: ValdrValidatorFn | null = {} as any;
+
+      beforeEach(() => {
+        validator = decimalMaxFactory!.createValidator({
+          value: 10,
+          inclusive: true,
+          message: 'Should be equal or less than 10.',
+        });
+      });
+
+      afterAll(() => (validator = null));
+
+      it('should not add message on lesser value', () => {
+        // given
+        const control: FormControl = new FormControl(9);
+
+        // when
+        const result = validator!(control);
+
+        // then
+        expect(result).toBeNull();
+      });
+
+      it('should add no message on equal value', () => {
+        // given
+        const control: FormControl = new FormControl('10');
+
+        // when
+        const result = validator!(control);
+
+        // then
+        expect(result).toEqual(null);
       });
     });
 

--- a/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-min-factory.spec.ts
+++ b/valdr-ng/projects/valdr-ng/src/lib/validators/decimal-min-factory.spec.ts
@@ -25,12 +25,48 @@ describe('DecimalMinFactory', () => {
       ).toBeDefined();
     });
 
+    describe('should validate without inclusive configuration', () => {
+      let validator: ValdrValidatorFn | null = {} as any;
+
+      beforeEach(() => {
+        validator = decimalMinFactory!.createValidator({
+          value: 10,
+          message: 'Should be equal or greater than 10.',
+        });
+      });
+
+      afterAll(() => (validator = null));
+
+      it('should not add message on greater value', () => {
+        // given
+        const control: FormControl = new FormControl(11);
+
+        // when
+        const result = validator!(control);
+
+        // then
+        expect(result).toBeNull();
+      });
+
+      it('should not add message on equal value', () => {
+        // given
+        const control: FormControl = new FormControl('10');
+
+        // when
+        const result = validator!(control);
+
+        // then
+        expect(result).toEqual(null);
+      });
+    });
+
     describe('should validate inclusive properly', () => {
       let validator: ValdrValidatorFn | null = {} as any;
 
       beforeEach(() => {
         validator = decimalMinFactory!.createValidator({
           value: 10,
+          inclusive: true,
           message: 'Should be greater than 10.',
         });
       });
@@ -48,7 +84,7 @@ describe('DecimalMinFactory', () => {
         expect(result).toBeNull();
       });
 
-      it('should add message on equal value', () => {
+      it('should not add message on equal value', () => {
         // given
         const control: FormControl = new FormControl('10');
 
@@ -56,14 +92,7 @@ describe('DecimalMinFactory', () => {
         const result = validator!(control);
 
         // then
-        expect(result).toEqual(
-          jasmine.objectContaining({
-            min: {
-              value: 10,
-              message: 'Should be greater than 10.',
-            },
-          })
-        );
+        expect(result).toEqual(null);
       });
     });
 


### PR DESCRIPTION
- when inclusive config is not provided in constraints equal values are valid
- update version